### PR TITLE
hw: Add `obi_uart`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+# Copyright 2025 ETH Zurich and University of Bologna.
+# Licensed under the Apache License, Version 2.0, see LICENSE for details.
+# SPDX-License-Identifier: Apache-2.0
+
+# Author: Nils Wistoff <nwistoff@iis.ee.ethz.ch>
+
+name: lint
+
+on: [ push, pull_request, workflow_dispatch ]
+
+jobs:
+  lint-license:
+    runs-on: ubuntu-latest
+    steps:
+      - name: lint license
+        uses: pulp-platform/pulp-actions/lint-license@v2.4.3
+        with:
+          license: |
+            Copyright (\d{4}(-\d{4})?\s)?(ETH Zurich and University of Bologna|lowRISC contributors).
+            (Solderpad Hardware License, Version 0.51|Licensed under the Apache License, Version 2.0), see LICENSE for details.
+            SPDX-License-Identifier: (SHL-0.51|Apache-2.0)
+
+  lint-sv:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Run Verible
+      uses: chipsalliance/verible-linter-action@main
+      with:
+        paths: hw
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        fail_on_error: true
+        reviewdog_reporter: github-check

--- a/Bender.yml
+++ b/Bender.yml
@@ -1,0 +1,24 @@
+# Copyright 2025 ETH Zurich and University of Bologna.
+# Solderpad Hardware License, Version 0.51, see LICENSE for details.
+# SPDX-License-Identifier: SHL-0.51
+
+package:
+  name: obi_peripherals
+  authors:
+    - "Philippe Sauter <phsauter@iis.ee.ethz.ch>"
+    - "Hannah Pochert  <hpochert@ethz.ch>"
+
+dependencies:
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git",   version: 1.37.0 }
+  obi:          { git: "https://github.com/pulp-platform/obi.git",            version: 0.1.3  }
+
+sources:
+  # obi_uart
+  - hw/obi_uart/obi_uart_pkg.sv
+  - hw/obi_uart/obi_uart_baudgen.sv
+  - hw/obi_uart/obi_uart_interrupts.sv
+  - hw/obi_uart/obi_uart_modem.sv
+  - hw/obi_uart/obi_uart_rx.sv
+  - hw/obi_uart/obi_uart_tx.sv
+  - hw/obi_uart/obi_uart_register.sv
+  - hw/obi_uart/obi_uart.sv

--- a/hw/obi_uart/obi_uart.sv
+++ b/hw/obi_uart/obi_uart.sv
@@ -1,0 +1,182 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Hannah Pochert  <hpochert@ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+module obi_uart #(
+  /// The OBI configuration connected to this peripheral.
+  parameter obi_pkg::obi_cfg_t ObiCfg = obi_pkg::ObiDefaultConfig, // SbrObiCfg
+  /// OBI request type
+  parameter type obi_req_t = logic,
+  /// OBI response type
+  parameter type obi_rsp_t = logic
+) (
+  input logic      clk_i,  // Primary input clock
+  input logic      rst_ni, // Asynchronous active-low reset
+
+  // OBI request interface
+  input  obi_req_t obi_req_i, // a.addr, a.we, a.be, a.wdata, a.aid, a.a_optional | rready, req
+  // OBI response interface
+  output obi_rsp_t obi_rsp_o, // r.rdata, r.rid, r.err, r.r_optional | gnt, rvalid
+
+  output logic     irq_o,   // Interrupt line
+  output logic     irq_no,  // Negated Interrupt line
+
+  input  logic     rxd_i,  // Serial Input
+  output logic     txd_o,  // Serial Output
+
+  // Modem control pins are optional
+  input  logic     cts_ni,  // Modem Inp Clear To Send
+  input  logic     dsr_ni,  // Modem Inp Data Send Request
+  input  logic     ri_ni,   // Modem Inp Ring Indicator
+  input  logic     cd_ni,   // Modem Inp Carrier Detect
+  output logic     rts_no,  // Modem Oup Ready To Send
+  output logic     dtr_no,  // Modem Oup DaTa Ready
+  output logic     out1_no, // Modem Oup DaTa Ready, optional outputs
+  output logic     out2_no  // Modem Oup DaTa Ready, optional outputs
+);
+  // Import the UART package for definitions and parameters
+  import obi_uart_pkg::*;
+
+  //--Receiver-and-Transmitter-Interface----------------------------------------------------------
+  logic rxd;
+  logic txd;
+
+  //--Receiver-Interrupt-Interface----------------------------------------------------------------
+  logic rx_fifo_trigger;
+  logic rx_timeout;
+
+  //--Register-Interface-Signals------------------------------------------------------------------
+  reg_read_t         reg_read;     // signals read from the registers
+  reg_write_t        reg_write;    // new values being written to registers
+
+  //--Baudenable-Interface-Signals----------------------------------------------------------------
+  logic oversample_rate_edge;
+  logic double_rate_edge;
+  logic baud_rate_edge;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // REGISTER INTERFACE //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  obi_uart_register #(
+    .obi_req_t (obi_req_t),
+    .obi_rsp_t (obi_rsp_t)
+  ) i_uart_register (
+    .clk_i,
+    .rst_ni,
+
+    .obi_req_i,
+    .obi_rsp_o,
+
+    .reg_read_o  (reg_read),
+    .reg_write_i (reg_write)
+  );
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // MODEM CONTROL //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  obi_uart_modem #(
+  ) i_uart_modem (
+    .clk_i,
+    .rst_ni,
+
+    .cts_ni,
+    .dsr_ni,
+    .ri_ni,
+    .cd_ni,
+    .rts_no,
+    .dtr_no,
+    .out1_no,
+    .out2_no,
+
+    .reg_read_i  (reg_read),
+    .reg_write_o (reg_write.modem)
+  );
+
+  //--Loopback-Mode-------------------------------------------------------------------------------
+  assign txd_o = (reg_read.mcr.loopback == 1'b1) ? 1'b1 : txd;
+  assign rxd   = (reg_read.mcr.loopback == 1'b1) ? txd  : rxd_i;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // BAUDRATE GENERATION //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  obi_uart_baudgen #(
+  ) i_uart_baudgen (
+    .clk_i,
+    .rst_ni,
+
+    .oversample_rate_edge_o(oversample_rate_edge),
+    .double_rate_edge_o    (double_rate_edge),
+    .baud_rate_edge_o      (baud_rate_edge),
+
+    .reg_read_i (reg_read)
+  );
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // RECEIVE //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  obi_uart_rx # (
+  ) i_uart_rx (
+    .clk_i,
+    .rst_ni,
+
+    .oversample_rate_edge_i (oversample_rate_edge),
+    .baud_rate_edge_i       (baud_rate_edge),
+
+    .rxd_i       (rxd),
+
+    .trigger_o   (rx_fifo_trigger),
+    .timeout_o   (rx_timeout),
+
+    .reg_read_i  (reg_read),
+    .reg_write_o (reg_write.rx)
+  );
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // TRANSMIT //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  obi_uart_tx # (
+  ) i_uart_tx (
+    .clk_i,
+    .rst_ni,
+
+    .baud_rate_edge_i   (baud_rate_edge),
+    .double_rate_edge_i (double_rate_edge),
+
+    .txd_o       (txd),
+
+    .reg_read_i  (reg_read),
+    .reg_write_o (reg_write.tx)
+  );
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // INTERRUPT CONTROL //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  obi_uart_interrupts #(
+  ) i_uart_interrupts (
+    .clk_i,
+    .rst_ni,
+
+    .rx_fifo_trigger,
+    .rx_timeout,
+
+    .irq_o,
+    .irq_no,
+
+    .reg_read_i  (reg_read),
+    .reg_write_i (reg_write),
+    .reg_isr_o (reg_write.isr)
+  );
+
+endmodule

--- a/hw/obi_uart/obi_uart_baudgen.sv
+++ b/hw/obi_uart/obi_uart_baudgen.sv
@@ -1,0 +1,114 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Hannah Pochert  <hpochert@ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+/// Generates clock enable signals for the required baud multiples
+module obi_uart_baudgen import obi_uart_pkg::*; #()
+(
+  input logic  clk_i,
+  input logic  rst_ni,
+
+  output logic oversample_rate_edge_o, // oversample clock enable signal
+  output logic double_rate_edge_o,     // doubled baud clock enable signal
+  output logic baud_rate_edge_o,       // baud clock enable signal
+
+  input reg_read_t reg_read_i
+);
+
+  // Import the UART package for definitions and parameters
+
+  //-- Configuration Signals ---------------------------------------------------------------------
+  logic [15:0] divisor;
+  logic        divisor_valid;
+
+  //-- Oversample Signals ------------------------------------------------------------------------
+  logic        oversample_is_divisor;
+  logic        oversample_clear;
+  logic [15:0] oversample_count;
+
+  //-- Double Baud Signals -----------------------------------------------------------------------
+  logic       clear_double_d, clear_double_q;
+  logic       count_is_double;
+
+  //-- Baud Signals ------------------------------------------------------------------------------
+  logic       baud_clear;
+  logic [3:0] baud_count;
+  logic       baud_count_overflow;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Clock Division //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  //----------------------------------------------------------------------------------------------
+  // Oversample 16x
+  //----------------------------------------------------------------------------------------------
+
+  // Concatenate most significant byte and least significant byte of Divisor
+  // -1 since we clear to zero when reaching divisor, takes one cycle
+  assign divisor = {reg_read_i.dlm, reg_read_i.dll} - 16'd1;
+  // divisor reset value is 0 and per the 16550A formula it has no meaning -> invalid
+  assign divisor_valid = ~(divisor == 0);
+  assign oversample_is_divisor = (oversample_count == divisor) & divisor_valid;
+  // clear on reaching the divisor or when configuration changes
+  assign oversample_clear = oversample_is_divisor | reg_read_i.obi_write_dllm;
+
+  counter #(
+    .WIDTH           (16),
+    .STICKY_OVERFLOW (0)
+  ) i_oversample_counter (
+    .clk_i,
+    .rst_ni,
+    .clear_i   ( oversample_clear ), // Synchronous clear: Sets Counter 0 in the next cycle
+    .en_i      ( divisor_valid    ), // Count only if configuration is high
+    .load_i    ( 1'b0             ),
+    .down_i    ( 1'b0             ), // Count upwards
+    .d_i       ( '0               ),
+    .q_o       ( oversample_count ),
+    .overflow_o(                  )  // Set when counter overflows from '1 to '0
+  );
+
+  // high for one clock cycle
+  assign oversample_rate_edge_o = (oversample_count == '0) & divisor_valid;
+
+  //----------------------------------------------------------------------------------------------
+  // Baudrate
+  //----------------------------------------------------------------------------------------------
+  // Counts when oversample hits target, counter has the new value in the next cycle
+  // the same cycle when oversample_rate_edge_o goes high
+
+  assign baud_clear = baud_count_overflow | reg_read_i.obi_write_dllm;
+
+  counter #(
+    .WIDTH          (4),
+    .STICKY_OVERFLOW(0)
+  ) i_baudrate_counter (
+    .clk_i,
+    .rst_ni,
+    .clear_i   ( baud_clear            ), // Synchronous clear: Sets Counter 0 in the next cycle
+    .en_i      ( oversample_is_divisor ), // Count every time oversample counter hits its target
+    .load_i    ( 1'b0                  ),
+    .down_i    ( 1'b0                  ), // Count upwards
+    .d_i       ( '0                    ),
+    .q_o       ( baud_count            ),
+    .overflow_o( baud_count_overflow   )
+  );
+
+  // oversample hits target, counter overflows on the next clock cycle and then clears itself
+  // therefore baud_rate_edge_o is high in the same cycle as oversample_rate_edge_o
+  assign baud_rate_edge_o = baud_count_overflow;
+
+  // Double baud rate directly generated from baudrate counter
+  assign count_is_double    = (baud_count[2:0] == '0); // last three bits zero
+  // clear_double turns the pulse off after one clock cycle
+  assign clear_double_d     = count_is_double;
+  assign double_rate_edge_o = count_is_double & ~clear_double_q;
+
+  `FF(clear_double_q, clear_double_d, '0, clk_i, rst_ni)
+
+endmodule

--- a/hw/obi_uart/obi_uart_interrupts.sv
+++ b/hw/obi_uart/obi_uart_interrupts.sv
@@ -1,0 +1,135 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Hannah Pochert  <hpochert@ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+/// Calculated interrupts and stores them until reset by hardware or by reading the ISR register
+module obi_uart_interrupts import obi_uart_pkg::*; #()
+(
+  input logic  clk_i,
+  input logic  rst_ni,
+
+  input  logic rx_fifo_trigger,
+  input  logic rx_timeout,
+
+  output logic irq_o,
+  output logic irq_no,
+
+  input  reg_read_t   reg_read_i,
+  input  reg_write_t  reg_write_i,
+  output isr_bits_t   reg_isr_o
+);
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Instantiations //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  //--Interrupt-Control-Signals-------------------------------------------------------------------
+  typedef struct packed {
+    logic       rls;       // Receive Line Status Interrupt - Error notification
+    logic       rxdr;      // Receiver Data Ready
+    logic       timeout;   // Reception Timeout
+    logic       thr_empty; // THR Empty Interrupt - Data can't be written
+    logic       mstat;     // Modem Status Interrupt - Changes in Modem Line
+  } reg_intrpt_t;
+
+  reg_intrpt_t intrpt_reg_d, intrpt_reg_q;
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Generare Interrupt Signals //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  always_comb begin
+    //--Receive-Line-Status-Interrupt-------------------------------------------------------------
+    intrpt_reg_d.rls = reg_read_i.ier.rlstat & (reg_write_i.rx.overrun | reg_write_i.rx.par_err |
+                        reg_write_i.rx.frame_err | reg_write_i.rx.break_irq);
+
+    //--Receive-Data-Ready-Interrupt--------------------------------------------------------------
+    if (reg_read_i.fcr.fifo_en) begin
+      intrpt_reg_d.rxdr = reg_read_i.ier.dtr & rx_fifo_trigger; // data ready in FIFO mode
+    end else begin
+      intrpt_reg_d.rxdr = reg_read_i.ier.dtr & reg_write_i.rx.data_ready; // in THR mode
+    end
+
+    //--Character-Timeout-Interrupt---------------------------------------------------------------
+    intrpt_reg_d.timeout = reg_read_i.fcr.fifo_en & reg_read_i.ier.dtr & rx_timeout;
+
+    //--THR-Empty-Interrupt-----------------------------------------------------------------------
+    intrpt_reg_d.thr_empty = reg_read_i.ier.thr_empty & reg_write_i.tx.thr_empty;
+
+    //--Modem-Status-Interrupt--------------------------------------------------------------------
+    intrpt_reg_d.mstat = reg_read_i.ier.mstat & (reg_write_i.modem.d_cts |
+      reg_write_i.modem.d_dsr | reg_write_i.modem.te_ri | reg_write_i.modem.d_cd);
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Interrupt Reset Condition //
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    if(reg_read_i.obi_read_lsr) begin
+      intrpt_reg_d.rls = 1'b0;
+    end
+
+    if(reg_read_i.obi_read_rhr) begin
+      intrpt_reg_d.timeout = 1'b0;
+      if(~reg_read_i.fcr.fifo_en) begin
+        intrpt_reg_d.rxdr = 1'b0;
+      end
+    end
+
+    if(reg_read_i.obi_write_thr) begin
+      intrpt_reg_d.thr_empty = 1'b0;
+    end
+
+    if (reg_read_i.obi_read_msr) begin
+      intrpt_reg_d.mstat = 1'b0;
+    end
+  end
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Setting ID & Status Bits //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  always_comb begin
+    //--Defaults----------------------------------------------------------------------------------
+    reg_isr_o.id       = 3'b000;
+    reg_isr_o.fifos_en = 2'b11; // Indicate 16550A FIFO support
+    reg_isr_o.unused4  = 1'b0;
+    reg_isr_o.unused5  = 1'b0;
+
+    reg_isr_o.status   = ~( |intrpt_reg_q );  // 0: interrupt present; 1: no interrupt
+
+    //--Priority-Encoder--------------------------------------------------------------------------
+    // 1. Priority Level
+    if (intrpt_reg_q.rls) begin
+      reg_isr_o.id     = 3'b011;
+    // 2. Priority Level
+    end else if (intrpt_reg_q.rxdr) begin
+      reg_isr_o.id     = 3'b010;
+    // 2. Priority Level
+    end else if (intrpt_reg_q.timeout) begin
+      reg_isr_o.id     = 3'b110;
+    // 3. Priority Level
+    end else if (intrpt_reg_q.thr_empty) begin
+      reg_isr_o.id     = 3'b001;
+    // 4. Priority Level
+    end else if (intrpt_reg_q.mstat) begin
+      reg_isr_o.id     = 3'b000;
+    end
+
+  end
+
+    //////////////////////////////////////////////////////////////////////////////////////////////
+    // Direct Output Interrupt - Alert the CPU //
+    //////////////////////////////////////////////////////////////////////////////////////////////
+
+    // Once high stays high until interrupt condition is removed
+    assign irq_o  = ~reg_isr_o.status;
+    assign irq_no = reg_isr_o.status;
+
+    `FF(intrpt_reg_q, intrpt_reg_d, '0, clk_i, rst_ni)
+
+endmodule

--- a/hw/obi_uart/obi_uart_modem.sv
+++ b/hw/obi_uart/obi_uart_modem.sv
@@ -1,0 +1,132 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Hannah Pochert  <hpochert@ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+/// Synchronizes incoming modem signals, outputs modem signals and handles loopback
+module obi_uart_modem import obi_uart_pkg::*; #()
+(
+  input  logic clk_i,
+  input  logic rst_ni,
+
+  input  logic cts_ni,  // Modem Inp Clear To Send
+  input  logic dsr_ni,  // Modem Inp Data Send Request
+  input  logic ri_ni,   // Modem Inp Ring Indicator
+  input  logic cd_ni,   // Modem Inp Carrier Detect
+  output logic rts_no,  // Modem Oup Ready To Send
+  output logic dtr_no,  // Modem Oup DaTa Ready
+  output logic out1_no, // Modem Output 1
+  output logic out2_no, // Modem Output 2
+
+  input  reg_read_t reg_read_i,
+  output msr_bits_t reg_write_o
+);
+  // Flow control is left to SW. UART Modem Control only writes modem inputs to
+  // register and sets modem outputs from the register.
+
+  // Modem inputs and outputs are active low. Values seen in the signals are the opposite of
+  // the ones read from or written to the modem status/control registers !
+
+  //--Modem-Control-Signals-----------------------------------------------------------------------
+  logic sync_cts_n, sync_cts_n_d, sync_cts_n_q;
+  logic sync_dsr_n, sync_dsr_n_d, sync_dsr_n_q;
+  logic sync_ri_n, sync_ri_n_d,  sync_ri_n_q;
+  logic sync_cd_n, sync_cd_n_d,  sync_cd_n_q;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Modem Input Synchronisation //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  sync #(
+    .STAGES (NrSyncStages)
+  ) i_sync_cts (
+    .clk_i,
+    .rst_ni,
+    .serial_i(cts_ni),
+    .serial_o(sync_cts_n)
+
+  );
+  sync #(
+    .STAGES (NrSyncStages)
+  ) i_sync_dsr (
+    .clk_i,
+    .rst_ni,
+    .serial_i(dsr_ni),
+    .serial_o(sync_dsr_n)
+  );
+
+  sync #(
+    .STAGES (NrSyncStages)
+  ) i_sync_ri (
+    .clk_i,
+    .rst_ni,
+    .serial_i(ri_ni),
+    .serial_o(sync_ri_n)
+  );
+
+  sync #(
+    .STAGES (NrSyncStages)
+  ) i_sync_cd (
+    .clk_i,
+    .rst_ni,
+    .serial_i(cd_ni),
+    .serial_o(sync_cd_n)
+  );
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Modem Input/Output and Loopback //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  always_comb begin
+    if(reg_read_i.mcr.loopback == 1'b1) begin
+      rts_no  = 1'b1;
+      dtr_no  = 1'b1;
+      out1_no = 1'b1;
+      out2_no = 1'b1;
+
+      sync_cts_n_d = ~reg_read_i.mcr.rts;
+      sync_dsr_n_d = ~reg_read_i.mcr.dtr;
+      sync_ri_n_d  = ~reg_read_i.mcr.out1;
+      sync_cd_n_d  = ~reg_read_i.mcr.out2;
+    end else begin
+      rts_no  = ~reg_read_i.mcr.rts;
+      dtr_no  = ~reg_read_i.mcr.dtr;
+      out1_no = ~reg_read_i.mcr.out1;
+      out2_no = ~reg_read_i.mcr.out2;
+
+      sync_cts_n_d = sync_cts_n;
+      sync_dsr_n_d = sync_dsr_n;
+      sync_ri_n_d  = sync_ri_n;
+      sync_cd_n_d  = sync_cd_n;
+    end
+  end
+
+  `FF(sync_cts_n_q, sync_cts_n_d, '1, clk_i, rst_ni)
+  `FF(sync_dsr_n_q, sync_dsr_n_d, '1, clk_i, rst_ni)
+  `FF(sync_ri_n_q, sync_ri_n_d, '1, clk_i, rst_ni)
+  `FF(sync_cd_n_q, sync_cd_n_d, '1, clk_i, rst_ni)
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Modem to MSR //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // Modem Inputs are negated
+  assign reg_write_o.cts  = ~sync_cts_n_d;
+  assign reg_write_o.dsr  = ~sync_dsr_n_d;
+  assign reg_write_o.ri   = ~sync_ri_n_d;
+  assign reg_write_o.cd   = ~sync_cd_n_d;
+
+    // Change status bits
+  assign reg_write_o.d_cts = sync_cts_n_d ^ sync_cts_n_q; // Delta: 1 if _d different from _q
+  assign reg_write_o.d_dsr = sync_dsr_n_d ^ sync_dsr_n_q; // Delta: 1 if _d different from _q
+  assign reg_write_o.te_ri = sync_ri_n_d & ~sync_ri_n_q;  // Trailing Edge: 1 on negedge
+  assign reg_write_o.d_cd  = sync_cd_n_d ^ sync_cd_n_q;   // Delta: 1 if _d different from _q
+
+endmodule

--- a/hw/obi_uart/obi_uart_pkg.sv
+++ b/hw/obi_uart/obi_uart_pkg.sv
@@ -1,0 +1,269 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Hannah Pochert  <hpochert@ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+package obi_uart_pkg;
+
+  //-- Configurable values -----------------------------------------------------------------------
+  localparam int RegAlignBytes = 4; // regs aligned to this many bytes (4 -> 32-bit aligned)
+
+  // Number of input synchronization stages
+  localparam int NrSyncStages = 2;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // RX and TX Statemachine typedefs //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // RX FSM states
+  typedef enum bit [2:0] {
+    RXIDLE,
+    RXSTART,
+    RXDATA,
+    RXPAR,
+    RXSTOP,
+    RXRESYNCHRONIZE
+  } state_type_rx_e;
+
+  // TX FSM states
+  typedef enum bit [2:0] {
+    TXIDLE,
+    TXSTART,
+    TXDATA,
+    TXPAR,
+    TXSTOP1,
+    TXSTOP2,
+    TXWAIT
+  } state_type_tx_e;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Address Offsets //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  localparam int RegWidth      = 8;
+  // Address widths used for decoding
+  localparam int AddressBits   = 3;
+  localparam int AddressOffset = $clog2(RegAlignBytes);
+
+  // Register Address Offsets
+  localparam bit [AddressBits-1:0] RegAddrRHR = 3'b000;
+  localparam bit [AddressBits-1:0] RegAddrTHR = 3'b000;
+  localparam bit [AddressBits-1:0] RegAddrIER = 3'b001;
+  localparam bit [AddressBits-1:0] RegAddrISR = 3'b010;
+  localparam bit [AddressBits-1:0] RegAddrFCR = 3'b010;
+  localparam bit [AddressBits-1:0] RegAddrLCR = 3'b011;
+  localparam bit [AddressBits-1:0] RegAddrMCR = 3'b100;
+  localparam bit [AddressBits-1:0] RegAddrLSR = 3'b101;
+  localparam bit [AddressBits-1:0] RegAddrMSR = 3'b110;
+  localparam bit [AddressBits-1:0] RegAddrSPR = 3'b111;
+  localparam bit [AddressBits-1:0] RegAddrDLL = 3'b000;
+  localparam bit [AddressBits-1:0] RegAddrDLM = 3'b001;
+  //localparam bit [AddressBits-1:0] RegAddrPSD = 3'b101;
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Single Register Unions for Register Interface//
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  //----------------------------------------------------------------------------------------------
+  // Single Register Structs with Bit Definitions
+  //----------------------------------------------------------------------------------------------
+
+  typedef struct packed {
+    logic [7:0] char_rx;     // Character received
+  } rhr_bits_t;
+
+  typedef struct packed {
+    logic [7:0] char_tx;     // Character transmitted
+  } thr_bits_t;
+
+  typedef struct packed {
+    logic unused7;           // Optional: DMA
+    logic unused6;           // Optional: DMA
+    logic unused5;           // 0
+    logic unused4;           // 0
+    logic mstat;             // Modem Status
+    logic rlstat;            // Receive Line Status
+    logic thr_empty;         // THR Empty
+    logic dtr;               // Data Ready or Reception Timeout
+  } ier_bits_t;
+
+  typedef struct packed {
+    logic [1:0] fifos_en;    // Standard: 2'b00: 8250; 2'b01: 16550; 2'b10: 16750; 2'b11: 16550A
+    logic unused5;           // Optional: DMA
+    logic unused4;           // Optional: DMA
+    logic [2:0] id;          // Intrpt Code ID
+    logic       status;      // Intrpt Status
+  } isr_bits_t;
+
+  typedef struct packed {
+    logic [1:0] rx_fifo_tl;  // Rx FIFO Trigger Level
+    logic       unused5;     // 0
+    logic       unused4;     // Optional: DMA
+    logic       unused3;     // Optional: DMA
+    logic       tx_fifo_rst; // Tx FIFO reset
+    logic       rx_fifo_rst; // Rx FIFO reset
+    logic       fifo_en;     // FIFO Enable
+  } fcr_bits_t;
+
+  typedef struct packed {
+    logic       dlab;        // DLAB Address multiplexing
+    logic       set_break;   // Set Break
+    logic       force_par;   // Force Parity
+    logic       even_par;    // Even Parity
+    logic       par_en;      // Parity Enable
+    logic       stop_bits;   // Stop Bits
+    logic [1:0] word_len;    // Word Length 2'b00: 5 | 2'b01: 6 | 2'b10: 7 | 2'b11: 8
+  } lcr_bits_t;
+
+  typedef struct packed {
+    logic       unused7;     // 0
+    logic       unused6;     // 0
+    logic       unused5;     // 0
+    logic       loopback;    // Loop Back
+    logic       out2;        // Optional: Gpio Output
+    logic       out1;        // Optional: Gpio Output
+    logic       rts;         // Request to Send
+    logic       dtr;         // DaTa Ready
+  } mcr_bits_t;
+
+  typedef struct packed {
+    logic fifo_err;          // FIFO Data Error
+    logic tx_empty;          // Transmitter Empty (no bits to send)
+    logic thr_empty;         // THR (and FIFO) Empty
+    logic break_irq;      // Break Interrupt
+    logic frame_err;         // Framing Error
+    logic par_err;           // Parity Error
+    logic overrun;       // Overrun Error
+    logic data_ready;        // Data Ready
+  } lsr_bits_t;
+
+  typedef struct packed {
+    logic cd;                // Carrier Detect
+    logic ri;                // Ring Indicator
+    logic dsr;               // Data Set Ready
+    logic cts;               // Clear to Send
+    logic d_cd;              // Delta CD: Indicates change
+    logic te_ri;             // Trailing Edge RI: Detects trailing Edge (Transition high to low)
+    logic d_dsr;             // Delta
+    logic d_cts;             // Delta Clear to Send
+  } msr_bits_t;
+
+  typedef struct packed {
+    logic [7:0] lsb;         // Baudrate's Divisor Constant LSByte
+  } dll_bits_t;
+
+  typedef struct packed {
+    logic [7:0] msb;         // Baudrate's Divisor Constant MSByte
+  } dlm_bits_t;
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Registers //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  typedef struct packed {
+    rhr_bits_t RHR;    // Read Hold Register
+    thr_bits_t THR;    // Transmit Hold Register
+    ier_bits_t IER;    // Interrupt Enable Register
+    //isr_bits_t ISR;  // Interrupt Status Register, stored seperately in interrupts module
+    fcr_bits_t FCR;    // Fifo Control Register
+    lcr_bits_t LCR;    // Line Control Register
+    mcr_bits_t MCR;    // Modem Control Register
+    lsr_bits_t LSR;    // Line Status Register
+    msr_bits_t MSR;    // Modem Status Register
+    //logic [7:0] SPR; // Scratch Pad Register, Not Implemented
+    dll_bits_t DLL;    // Divisor Latch Least signf. byte
+    dlm_bits_t DLM;    // Divisor Latch Most sign. byte
+    //logic [7:0] PSD; // Pre Scaler Division, Optional
+  } uart_reg_fields_t;
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Default/Reset Register Values //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // Default values for the Registers from UART 16550A Standard
+  localparam uart_reg_fields_t RegResetVal = '{
+    RHR: 8'h00,
+    THR: 8'h00,
+    IER: 8'h00,
+    // ISR: 8'hC1, // -> 11000001; bit 6 and 7 high -> 16550A (implemented in interrupt module)
+    FCR: 8'h00,
+    LCR: 8'h00,
+    MCR: 8'h00,
+    LSR: 8'h60,
+    MSR: 8'h00,
+    // SPR: 8'h00, // scratch reg not implemented, always return zero
+    DLL: 8'h01,
+    DLM: 8'h00
+    // PSD: PSD_DEFAULT //  PSD not implemented
+  };
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Interface between UART INTERNAL LOGIC and Register //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  typedef struct packed {
+    // current register values
+    thr_bits_t thr;
+    ier_bits_t ier;
+    isr_bits_t isr;
+    fcr_bits_t fcr;
+    lcr_bits_t lcr;
+    mcr_bits_t mcr;
+    dll_bits_t dll;
+    dlm_bits_t dlm;
+    // read/write indicators
+    logic      obi_read_rhr;
+    logic      obi_read_isr;
+    logic      obi_read_lsr;
+    logic      obi_read_msr;
+    logic      obi_write_thr;
+    logic      obi_write_dllm;
+  } reg_read_t;
+
+  // new values from rx module
+  typedef struct packed {
+    rhr_bits_t  rhr;
+    logic       fifo_rst;
+    logic       fifo_err;
+    logic       data_ready;
+    logic       overrun;
+    logic       par_err;
+    logic       frame_err;
+    logic       break_irq;
+
+    logic       rhr_valid;
+    logic       fifo_rst_valid;
+    logic       fifo_err_valid;
+    logic       dr_valid;
+    logic       overrun_valid;
+    logic       par_valid;
+    logic       frame_valid;
+    logic       break_valid;
+  } rx_reg_write_t;
+
+  // new values from tx module
+  typedef struct packed {
+    logic       fifo_rst;
+    logic       tx_empty;
+    logic       thr_empty;
+
+    logic       fifo_rst_valid;
+    logic       empty_valid;
+    logic       thr_valid;
+  } tx_reg_write_t;
+
+  typedef struct packed {
+    rx_reg_write_t rx;
+    tx_reg_write_t tx;
+    isr_bits_t     isr;
+    msr_bits_t     modem;
+  } reg_write_t;
+
+
+endpackage

--- a/hw/obi_uart/obi_uart_register.sv
+++ b/hw/obi_uart/obi_uart_register.sv
@@ -1,0 +1,305 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Hannah Pochert  <hpochert@ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+module obi_uart_register import obi_uart_pkg::*; #(
+  /// The OBI configuration connected to this peripheral.
+  parameter obi_pkg::obi_cfg_t ObiCfg = obi_pkg::ObiDefaultConfig, // SbrObiCfg
+  /// OBI request type
+  parameter type obi_req_t = logic,
+  /// OBI response type
+  parameter type obi_rsp_t = logic
+) (
+  input logic clk_i,
+  input logic rst_ni,
+
+  // OBI request interface
+  input obi_req_t  obi_req_i, // a.addr, a.we, a.be, a.wdata, a.aid, a.a_optional | rready, req
+  // OBI response interface
+  output obi_rsp_t obi_rsp_o, // r.rdata, r.rid, r.err, r.r_optional | gnt, rvalid
+
+  output reg_read_t reg_read_o,   // Current register values
+  input  reg_write_t reg_write_i  // Internal updates to register values
+);
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Obi Preparations //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // Signals for the OBI response
+  logic [ObiCfg.DataWidth-1:0] rsp_data;
+  logic                        valid_d, valid_q;         // delayed for the response phase
+  logic                        err;
+  logic                        w_err_d, w_err_q;
+  logic [AddressBits-1:0]      word_addr_d, word_addr_q; // delayed for the response phase
+  logic [ObiCfg.IdWidth-1:0]   id_d, id_q;               // delayed for the response phase
+  logic                        we_d, we_q;
+  logic                        req_d, req_q;
+
+  // OBI rsp Assignment
+  always_comb begin
+    obi_rsp_o         = '0;
+    obi_rsp_o.r.rdata = rsp_data;
+    obi_rsp_o.r.rid   = id_q;
+    obi_rsp_o.r.err   = err;
+    obi_rsp_o.gnt     = obi_req_i.req;
+    obi_rsp_o.rvalid  = valid_q;
+  end
+
+  // id, valid and address handling
+  assign id_d         = obi_req_i.a.aid;
+  assign valid_d      = obi_req_i.req;
+  assign word_addr_d  = obi_req_i.a.addr[AddressOffset+:AddressBits];
+  assign we_d         = obi_req_i.a.we;
+  assign req_d        = obi_req_i.req;
+
+  // FF for the obi rsp signals (id and valid)
+  `FF(id_q, id_d, '0, clk_i, rst_ni)               // 5 Bits
+  `FF(valid_q, valid_d, '0, clk_i, rst_ni)         // 1 Bit
+  `FF(word_addr_q, word_addr_d, '0, clk_i, rst_ni) // #AddressBits Bits
+  `FF(we_q, we_d, '0, clk_i, rst_ni)               // 1 Bit
+  `FF(w_err_q, w_err_d, '0, clk_i, rst_ni)         // 1 Bit
+  `FF(req_q, req_d, '0, clk_i, rst_ni)             // 1 Bit
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Registers //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  uart_reg_fields_t reg_d, reg_q;
+  uart_reg_fields_t new_reg; // next value of the registers if no read/write occurs (hw update)
+
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // COMB LOGIC //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  rx_reg_write_t write_rx;
+  tx_reg_write_t write_tx;
+
+  assign write_tx = reg_write_i.tx;
+  assign write_rx = reg_write_i.tx;
+
+  // output current register values
+  assign reg_read_o.thr = reg_q.THR;
+  assign reg_read_o.ier = reg_q.IER;
+  assign reg_read_o.isr = reg_write_i.isr;
+  assign reg_read_o.fcr = reg_q.FCR;
+  assign reg_read_o.lcr = reg_q.LCR;
+  assign reg_read_o.mcr = reg_q.MCR;
+  assign reg_read_o.dll = reg_q.DLL;
+  assign reg_read_o.dlm = reg_q.DLM;
+
+  //-- Internal updates to registers -------------------------------------------------------------
+  always_comb begin : hw_update
+    // shorthand signal names
+    rx_reg_write_t write_rx = reg_write_i.rx;
+    tx_reg_write_t write_tx = reg_write_i.tx;
+
+    // default
+    new_reg = reg_q;
+
+    // Flow Control Register
+    new_reg.FCR.rx_fifo_rst = write_rx.fifo_rst_valid ? write_rx.fifo_rst : reg_q.FCR.rx_fifo_rst;
+    new_reg.FCR.tx_fifo_rst = write_tx.fifo_rst_valid ? write_tx.fifo_rst : reg_q.FCR.tx_fifo_rst;
+
+    new_reg.RHR = write_rx.rhr_valid ? write_rx.rhr : reg_q.RHR;
+
+    // Line Status Register
+    new_reg.LSR.fifo_err   = write_rx.fifo_err_valid ? write_rx.fifo_err   : reg_q.LSR.fifo_err;
+    new_reg.LSR.tx_empty   = write_tx.empty_valid    ? write_tx.tx_empty   : reg_q.LSR.tx_empty;
+    new_reg.LSR.thr_empty  = write_tx.thr_valid      ? write_tx.thr_empty  : reg_q.LSR.thr_empty;
+    new_reg.LSR.break_irq  = write_rx.break_valid    ? write_rx.break_irq  : reg_q.LSR.break_irq;
+    new_reg.LSR.frame_err  = write_rx.frame_valid    ? write_rx.frame_err  : reg_q.LSR.frame_err;
+    new_reg.LSR.par_err    = write_rx.par_valid      ? write_rx.par_err    : reg_q.LSR.par_err;
+    new_reg.LSR.data_ready = write_rx.dr_valid       ? write_rx.data_ready : reg_q.LSR.data_ready;
+    new_reg.LSR.overrun    = write_rx.overrun_valid  ? write_rx.overrun    : reg_q.LSR.overrun;
+
+    // Modem Status Register
+    new_reg.MSR.cd    = reg_write_i.modem.cd;
+    new_reg.MSR.ri    = reg_write_i.modem.ri;
+    new_reg.MSR.dsr   = reg_write_i.modem.dsr;
+    new_reg.MSR.cts   = reg_write_i.modem.cts;
+    // remains high once set until cleared by read
+    new_reg.MSR.d_cd  = reg_q.MSR.d_cd  | reg_write_i.modem.d_cd;
+    new_reg.MSR.te_ri = reg_q.MSR.te_ri | reg_write_i.modem.te_ri;
+    new_reg.MSR.d_dsr = reg_q.MSR.d_dsr | reg_write_i.modem.d_dsr;
+    new_reg.MSR.d_cts = reg_q.MSR.d_cts | reg_write_i.modem.d_cts;
+  end
+
+  //-- Software updates to registers -------------------------------------------------------------
+  always_comb begin
+    // default
+    err     = w_err_q;
+    w_err_d = 1'b0;
+
+    // read/write indicators
+    reg_read_o.obi_read_rhr  = 1'b0;
+    reg_read_o.obi_read_isr  = 1'b0;
+    reg_read_o.obi_read_lsr  = 1'b0;
+    reg_read_o.obi_read_msr  = 1'b0;
+    reg_read_o.obi_write_thr = 1'b0;
+    reg_read_o.obi_write_dllm = 1'b0;
+
+    rsp_data = 32'h0;
+
+    reg_d = new_reg;
+
+    //-- OBI-Writes ------------------------------------------------------------------------------
+    if (obi_req_i.req & obi_req_i.a.we & obi_req_i.a.be[0]) begin
+
+      w_err_d = 1'b0;
+
+      if (~reg_q.LCR[7]) begin // DLAB = 0 Address Decode
+
+        case (word_addr_d)
+          RegAddrTHR: begin
+            reg_d.THR = obi_req_i.a.wdata[RegWidth-1:0];
+            reg_read_o.obi_write_thr = 1'b1;
+          end
+
+          RegAddrIER: begin
+            reg_d.IER = obi_req_i.a.wdata[RegWidth-1:0];
+          end
+
+          RegAddrFCR: begin
+            reg_d.FCR = obi_req_i.a.wdata[RegWidth-1:0];
+          end
+
+          RegAddrLCR: begin
+            reg_d.LCR = obi_req_i.a.wdata[RegWidth-1:0];
+          end
+
+          RegAddrMCR: begin
+            reg_d.MCR = obi_req_i.a.wdata[RegWidth-1:0];
+          end
+
+          RegAddrSPR: begin
+            // no error but ignored (SPR always returns 0)
+          end
+
+          default: begin
+            w_err_d = 1'b1; // unmapped register access
+          end
+        endcase
+
+      end else begin // DLAB = 1 Address Decode
+
+        case (word_addr_d)
+          RegAddrDLL: begin
+            reg_d.DLL = obi_req_i.a.wdata[RegWidth-1:0];
+            reg_read_o.obi_write_dllm = 1'b1;
+          end
+
+          RegAddrDLM: begin
+            reg_d.DLM = obi_req_i.a.wdata[RegWidth-1:0];
+            reg_read_o.obi_write_dllm = 1'b1;
+          end
+
+          RegAddrFCR: begin
+            reg_d.FCR = obi_req_i.a.wdata[RegWidth-1:0];
+          end
+
+          RegAddrLCR: begin
+            reg_d.LCR = obi_req_i.a.wdata[RegWidth-1:0];
+          end
+
+          RegAddrMCR: begin
+            reg_d.MCR = obi_req_i.a.wdata[RegWidth-1:0];
+          end
+
+          RegAddrSPR: begin
+            // no error but ignored (SPR always returns 0)
+          end
+
+          default: begin
+            w_err_d = 1'b1; // unmapped register access
+          end
+        endcase
+
+      end
+
+    end
+
+    //-- OBI-Read --------------------------------------------------------------------------------
+    if (req_q & ~we_q) begin
+
+      err = 1'b0;
+
+      if (~reg_q.LCR[7]) begin // DLAB = 0 Address Decode
+
+        case (word_addr_q)
+          RegAddrRHR: begin
+            rsp_data[RegWidth-1:0] = reg_q.RHR;
+            reg_read_o.obi_read_rhr  = 1'b1;
+          end
+
+          RegAddrIER: begin
+            rsp_data[RegWidth-1:0] = reg_q.IER;
+          end
+
+          RegAddrISR: begin
+            rsp_data[RegWidth-1:0] = reg_write_i.isr;
+            reg_read_o.obi_read_isr  = 1'b1;
+          end
+
+          RegAddrLCR: begin
+            rsp_data[RegWidth-1:0] = reg_q.LCR;
+          end
+
+          RegAddrMCR: begin
+            rsp_data[RegWidth-1:0] = reg_q.MCR;
+          end
+
+          RegAddrLSR: begin
+            rsp_data[RegWidth-1:0] = reg_q.LSR;
+            reg_read_o.obi_read_lsr  = 1'b1;
+          end
+
+          RegAddrMSR: begin
+            rsp_data[RegWidth-1:0] = reg_q.MSR;
+            reg_d.MSR = reg_write_i.modem; // sticky bits cleared
+          end
+
+          RegAddrSPR: begin
+            rsp_data[RegWidth-1:0] = '0; // not implemented
+          end
+
+          default: begin
+            err = 1'b1;
+          end
+        endcase
+
+      end else begin // DLAB = 1 Address Decode
+
+        case (word_addr_q)
+          RegAddrDLL: begin
+            rsp_data[RegWidth-1:0] = reg_q.DLL;
+          end
+
+          RegAddrDLM: begin
+            rsp_data[RegWidth-1:0] = reg_q.DLM;
+          end
+
+          default: begin
+            err = 1'b1;
+          end
+        endcase
+
+      end
+
+    end
+
+  end
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // SEQUENTIAL LOGIC //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  `FF(reg_q, reg_d, obi_uart_pkg::RegResetVal, clk_i, rst_ni)
+
+endmodule

--- a/hw/obi_uart/obi_uart_rx.sv
+++ b/hw/obi_uart/obi_uart_rx.sv
@@ -1,0 +1,572 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Hannah Pochert  <hpochert@ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+module obi_uart_rx import obi_uart_pkg::*; #()
+(
+  input logic  clk_i,
+  input logic  rst_ni,
+
+  input logic  oversample_rate_edge_i,
+  input logic  baud_rate_edge_i,
+
+  input logic  rxd_i,
+
+  output logic trigger_o,
+  output logic timeout_o,
+
+  input  reg_read_t     reg_read_i,
+  output rx_reg_write_t reg_write_o
+);
+
+  //--Timing--------------------------------------------------------------------------------------
+  logic timing_bit_center_q, timing_bit_center_d;
+  logic timing_bit_center_edge;
+  logic timing_clear;
+  logic timing_init_clear;
+  logic timing_load;
+  logic [4:0] timing_offset;
+  logic [4:0] timing_count;
+
+  //--Synchronization-Signals---------------------------------------------------------------------
+  logic sync_rxd;
+
+  //--Majority-Filter-Signals---------------------------------------------------------------------
+  logic [1:0] high_count_q, high_count_d;
+  logic filtered_rxd_q, filtered_rxd_d;
+
+  //--FIFO-signals--------------------------------------------------------------------------------
+  logic fifo_clear;
+  logic fifo_full;
+  logic fifo_empty;
+  logic [3:0] fifo_usage;
+  logic [10:0] fifo_data_i;
+  logic [10:0] fifo_data_o;
+  logic fifo_push;
+  logic fifo_pop;
+  // FIFO Write
+  logic break_interrupt;
+  logic [3:0] fifo_error_index_q, fifo_error_index_d;
+  // FIFO trigger
+  logic [3:0] tl_characters;
+  // FIFO timeout
+  // longest character: 1 start, 8 data, 1 parity, 2 stop -> 12bit
+  // timeout occurs after 4 characters -> 48bit -> $clog2(48) = 6
+  logic [3:0] character_length;
+  logic [5:0] timeout_level;
+  logic [5:0] timeout_count_q, timeout_count_d;
+
+  //--Write-Read-FIFO-or-Write-RHR----------------------------------------------------------------
+  logic rhr_full_q, rhr_full_d;
+
+  //--Statemachine-Transition-Signals-------------------------------------------------------------
+  state_type_rx_e state_q, state_d;
+  logic rsr_finish;
+  logic par_finish;
+  logic stop_finish;
+  logic write_init;
+
+  //--Statemachine-RSR-Signals--------------------------------------------------------------------
+  logic [7:0] rsr_q, rsr_d;
+  logic [2:0] bitcount_q, bitcount_d; // Count up to character_len
+  logic [2:0] word_len_bits;          // 5-8 Bits
+
+  //--Statemachine-Error-Signals------------------------------------------------------------------
+  // Parity Check
+  logic parity_err_q, parity_err_d;
+  logic data_parity;
+  // Stop Bit Check
+  logic framing_err_q, framing_err_d;
+  logic break_q, break_d;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Timing //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  //----------------------------------------------------------------------------------------------
+  // Counter Instantiation
+  //----------------------------------------------------------------------------------------------
+
+  //--Clear-Counter-------------------------------------------------------------------------------
+  assign timing_clear = ((timing_count == 5'b01111) && oversample_rate_edge_i)
+                        | (timing_init_clear) ? 1'b1 : 1'b0;
+
+  counter #(
+    .WIDTH          (5),
+    .STICKY_OVERFLOW(0)
+  ) i_counter (
+    .clk_i,
+    .rst_ni,
+    .clear_i   (timing_clear),         // Synchronous clear: Sets Counter 0 in the next cycle
+    .en_i      (oversample_rate_edge_i),
+    .load_i    (timing_load),
+    .down_i    (1'b0),                 // Always count upwards
+    .d_i       (timing_offset),
+    .q_o       (timing_count),
+    .overflow_o()
+  );
+
+  //----------------------------------------------------------------------------------------------
+  // Timing Bit Center
+  //----------------------------------------------------------------------------------------------
+  // Is high for one oversample_rate cycle
+  assign timing_bit_center_d    = (timing_count == 5'b01000) ? 1'b1 : 1'b0;
+  // Edge is high for one clk_i cycle
+  assign timing_bit_center_edge = (timing_bit_center_d & ~timing_bit_center_q) ? 1'b1 : 1'b0;
+
+  `FF(timing_bit_center_q, timing_bit_center_d, '0, clk_i, rst_ni)
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Input Stages //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  //----------------------------------------------------------------------------------------------
+  // 2-Stage Input Synchronization
+  //----------------------------------------------------------------------------------------------
+  sync #(
+    .STAGES (NrSyncStages)
+  ) i_sync (
+    .clk_i,
+    .rst_ni,
+    .serial_i(rxd_i),
+    .serial_o(sync_rxd)
+  );
+
+  //----------------------------------------------------------------------------------------------
+  // 3-Sample Majority Filter
+  //----------------------------------------------------------------------------------------------
+  // The Majority Filter takes 3 samples and sets filtered_rxd high if at least 2 of them are high
+
+  always_comb begin
+
+    high_count_d = high_count_q;
+    filtered_rxd_d = filtered_rxd_q;
+
+    if (timing_count == 5'b00100) begin // Start reset in cycle 5: "Majority Init"
+      high_count_d = 2'b00;
+    end else if (oversample_rate_edge_i) begin
+      if (sync_rxd & (timing_count < 5'b00111)) begin // Take samples in Cycle 6, 7, 8
+        high_count_d = high_count_q + 1;
+      end else if (timing_count == 5'b00111) begin // filtered_rxd is set for Oversample Cycle 8
+        if ((high_count_q == 2'b10) | (high_count_q == 2'b11) ) begin
+          filtered_rxd_d = 1'b1;
+        end else begin
+          filtered_rxd_d = 1'b0;
+        end
+      end
+    end
+
+  end
+
+  `FF(high_count_q, high_count_d, '0, clk_i, rst_ni)
+  `FF(filtered_rxd_q, filtered_rxd_d, 1'b1, clk_i, rst_ni)
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // FIFO Instantiation//
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  fifo_v3 # (
+    .FALL_THROUGH(),
+    .DATA_WIDTH  (11),
+    .DEPTH       (16),
+    .dtype       (),
+    .ADDR_DEPTH  ()  // DO NOT OVERWRITE THIS PARAMETER
+  ) i_fifo_v3 (
+    .clk_i,                   // Clock
+    .rst_ni,                  // Asynchronous reset active low
+    .flush_i   (fifo_clear),  // flush the queue
+    .testmode_i(1'b0),
+    // status flags
+    .full_o    (fifo_full),   // queue is full
+    .empty_o   (fifo_empty),  // queue is empty
+    .usage_o   (fifo_usage),  // fill pointer
+    // as long as the queue is not full we can push new data
+    .data_i    (fifo_data_i), // data to push into the queue
+    .push_i    (fifo_push),   // data is valid and can be pushed to the queue
+    // as long as the queue is not empty we can pop new elements
+    .data_o    (fifo_data_o), // output data
+    .pop_i     (fifo_pop)     // pop head from queue
+  );
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // General Logic //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  always_comb begin
+
+    //--------------------------------------------------------------------------------------------
+    // Defaults
+    //--------------------------------------------------------------------------------------------
+    break_interrupt = 1'b0;
+
+    //--FIFO Combinational------------------------------------------------------------------------
+    fifo_clear    = 1'b1; // Reset
+
+    trigger_o       = 1'b0;    // trigger_o
+    tl_characters = 4'b0001; // trigger_o
+
+    fifo_push     = 1'b0; // Write
+    fifo_data_i   = '0;   // Write
+
+    timeout_count_d = timeout_count_q;
+    timeout_o         = 1'b0; // timeout_o
+    timeout_level = '0;
+
+    fifo_error_index_d = fifo_error_index_q; // FIFO Error
+
+    //--Register Interface------------------------------------------------------------------------
+    reg_write_o = '0;
+
+    //--Statemachine Combinational----------------------------------------------------------------
+    state_d       = state_q; // Pass along state
+    rsr_d         = rsr_q;
+    bitcount_d    = bitcount_q;
+    parity_err_d  = parity_err_q;
+    framing_err_d = framing_err_q;
+    break_d       = break_q; // Break Interrupt information for Parity and Stop Bits
+
+    rsr_finish  = 1'b0;
+    par_finish  = 1'b0;
+    stop_finish = 1'b0;
+    write_init  = 1'b0;
+
+    data_parity = 1'b0;
+
+    timing_init_clear = 1'b0;
+    timing_load       = 1'b0;
+    timing_offset     = 5'b00000;
+
+    //--RHR-Combinational-------------------------------------------------------------------------
+    fifo_clear = 1'b1;
+    fifo_pop   = 1'b0;
+    rhr_full_d = rhr_full_q;
+
+    //--------------------------------------------------------------------------------------------
+    // Word Length
+    //--------------------------------------------------------------------------------------------
+    case (reg_read_i.lcr.word_len)
+      2'b00: word_len_bits = 3'b100; // 5 Bits (4th index in rsr)
+      2'b01: word_len_bits = 3'b101; // 6 Bits (5th index in rsr)
+      2'b10: word_len_bits = 3'b110; // 7 Bits (6th index in rsr)
+      2'b11: word_len_bits = 3'b111; // 8 Bits (7th index in rsr)
+      default: word_len_bits = 3'b111;
+    endcase
+
+    //--------------------------------------------------------------------------------------------
+    // Clear RHR & LSR after OBI read
+    //--------------------------------------------------------------------------------------------
+
+    //-Clear-RHR-and-Reset-Data-Ready-Bit---------------------------------------------------------
+    if (reg_read_i.obi_read_rhr) begin
+      reg_write_o.rhr        = '0;
+      reg_write_o.rhr_valid  = 1'b1;
+
+      rhr_full_d             = 1'b0;
+
+      reg_write_o.data_ready = 1'b0;
+      reg_write_o.dr_valid   = 1'b1;
+    end
+
+    if (reg_read_i.obi_read_lsr) begin // Clear LSR
+      reg_write_o.overrun   = 1'b0;
+      reg_write_o.par_err       = 1'b0;
+      reg_write_o.frame_err     = 1'b0;
+      reg_write_o.break_irq  = 1'b0;
+      reg_write_o.overrun_valid = 1'b0;
+      reg_write_o.par_valid     = 1'b0;
+      reg_write_o.frame_valid   = 1'b0;
+      reg_write_o.break_valid   = 1'b0;
+      if (fifo_error_index_q == 4'b0000) begin
+        reg_write_o.fifo_err       = 1'b0;
+        reg_write_o.fifo_err_valid = 1'b1;
+      end
+    end
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Statemachine Combinational //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    //--------------------------------------------------------------------------------------------
+    // RSR - Receiver Shift Register (serial to parallel)
+    //--------------------------------------------------------------------------------------------
+    // After rsr_finish, rsr_q is stored until the next time we are in START state
+    if (state_q == RXDATA) begin
+      if (timing_bit_center_edge & (bitcount_q <= word_len_bits)) begin
+        rsr_d[bitcount_q] = filtered_rxd_q;
+        bitcount_d        = bitcount_q + 1;
+        if (bitcount_q == word_len_bits) begin
+          rsr_finish = 1'b1;
+        end
+      end
+    end
+
+    //--------------------------------------------------------------------------------------------
+    // Parity Check
+    //--------------------------------------------------------------------------------------------
+    if (state_q == RXPAR) begin
+      parity_err_d = 1'b0;
+      data_parity  = ^rsr_q; // XOR to compute parity of data bits
+
+      if (timing_bit_center_edge) begin
+        case (reg_read_i.lcr[5:4]) // Read Parity Configuration
+          2'b00: parity_err_d = (data_parity == filtered_rxd_q); // Odd Parity
+          2'b01: parity_err_d = (data_parity != filtered_rxd_q); // Even Parity
+          2'b10: parity_err_d = (~filtered_rxd_q);               // Forced 1
+          2'b11: parity_err_d = filtered_rxd_q;                  // Forced 0
+          default: parity_err_d = 1'b0;
+        endcase
+        break_d    = break_q | filtered_rxd_q;
+        par_finish = 1'b1;
+      end
+    end
+
+    //--------------------------------------------------------------------------------------------
+    // Stop Bit Check
+    //--------------------------------------------------------------------------------------------
+    if (state_q == RXSTOP) begin
+      framing_err_d = 1'b0;
+      if (timing_bit_center_edge) begin
+        break_d     = break_q | filtered_rxd_q;
+        write_init  = 1'b1;
+        stop_finish = 1'b1;
+        if (!filtered_rxd_q) begin
+          framing_err_d = 1'b1;
+        end else begin
+          framing_err_d = 1'b0;
+        end
+      end
+    end
+
+    //--------------------------------------------------------------------------------------------
+    // State Transformation
+    //--------------------------------------------------------------------------------------------
+    case(state_q)
+      RXIDLE: begin
+        if (~sync_rxd) begin
+          state_d = RXSTART;
+          timing_init_clear = 1'b0;
+          if (oversample_rate_edge_i) begin
+            timing_load   = 1'b1;
+            timing_offset = 5'b00010; // If first cycle not detected: Set Timing Counter to 2
+          end
+        end
+        timing_init_clear = 1'b1;
+      end
+
+      RXSTART: begin
+        if (timing_bit_center_edge) begin
+          if (~filtered_rxd_q) begin
+            bitcount_d = 3'b000;
+            rsr_d      = '0;
+            state_d = RXDATA;
+          end else begin
+            state_d = RXIDLE;
+          end
+        end
+      end
+
+      RXDATA: begin // Stays in this state for "word_len_bits" baud_cycles
+        if (rsr_finish) begin
+          if (reg_read_i.lcr.par_en) begin
+            state_d = RXPAR;
+          end else begin
+            state_d = RXSTOP;
+          end
+        end
+      end
+
+      RXPAR: begin
+        if (par_finish) begin
+          state_d = RXSTOP;
+        end
+      end
+
+      RXSTOP: begin
+        if (stop_finish) begin
+          if (framing_err_q) begin
+            state_d = RXRESYNCHRONIZE;
+          end else begin
+            state_d = RXIDLE;
+          end
+        end
+      end
+
+      RXRESYNCHRONIZE: begin
+        if (~sync_rxd) begin
+          state_d = RXSTART;
+        end else begin
+          state_d = RXIDLE;
+        end
+      end
+
+      default: state_d = RXIDLE;
+    endcase
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // WRITE RHR Combinational //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    //--------------------------------------------------------------------------------------------
+    // Write RHR
+    //--------------------------------------------------------------------------------------------
+    if (reg_read_i.fcr.fifo_en) begin // FIFO enabled
+
+      // data ready when a character is moved from rsr or fifo to rhr or rhr already has data
+      reg_write_o.dr_valid   = 1'b1;
+      reg_write_o.data_ready = write_init | ~fifo_empty | rhr_full_q;
+
+      //--Write-FIFO-to-RHR-----------------------------------------------------------------------
+      if ((~rhr_full_q) & (~fifo_empty)) begin
+        reg_write_o.rhr      = fifo_data_o[7:0];
+        reg_write_o.rhr_valid            = 1'b1;
+        reg_write_o.data_ready           = 1'b1;
+        rhr_full_d                       = 1'b1;
+
+        // If Fifo Enabled, always set LSR bits with the Data on top of the FIFO
+        reg_write_o.break_irq = fifo_data_o[8];
+        reg_write_o.frame_err    = fifo_data_o[9];
+        reg_write_o.par_err      = fifo_data_o[10];
+        reg_write_o.break_valid  = 1'b1;
+        reg_write_o.frame_valid  = 1'b1;
+        reg_write_o.par_valid    = 1'b1;
+        fifo_pop                 = 1'b1;
+
+        if (4'b0000 != fifo_error_index_q) begin
+          fifo_error_index_d = fifo_error_index_q - 'b0001;
+        end
+      end
+
+    end else begin // FIFO disabled : RHR acts as 1-Byte Holding Register
+
+      //--Write-RSR-to-RHR------------------------------------------------------------------------
+      if (write_init) begin
+        if (rhr_full_q) begin
+          reg_write_o.overrun   = 1'b1;
+          reg_write_o.overrun_valid = 1'b1;
+        end
+        reg_write_o.rhr          = rsr_q; // If full, RHR just gets overwritten
+        reg_write_o.rhr_valid    = 1'b1;
+        rhr_full_d               = 1'b1;
+
+        reg_write_o.data_ready   = 1'b1; // Set Data Ready Bit
+        reg_write_o.dr_valid     = 1'b1;
+        reg_write_o.par_err      = parity_err_q;
+        reg_write_o.frame_err    = framing_err_q;
+        break_interrupt          = & (~{break_q, rsr_q}); // All character bits 0 ?
+        reg_write_o.break_irq = break_interrupt;
+        reg_write_o.break_irq = 1'b1;
+        reg_write_o.break_valid  = 1'b1;
+        reg_write_o.par_valid    = 1'b1;
+        reg_write_o.frame_valid  = 1'b1;
+      end
+
+    end
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // FIFO Combinational //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    if (reg_read_i.fcr.fifo_en) begin
+      //------------------------------------------------------------------------------------------
+      // FIFO Reset
+      //------------------------------------------------------------------------------------------
+      fifo_clear = 1'b0;
+
+      if (reg_read_i.fcr.rx_fifo_rst) begin
+        fifo_clear                  = 1'b1;
+        reg_write_o.fifo_rst        = 1'b0;
+        reg_write_o.fifo_rst_valid  = 1'b1;
+      end
+      //------------------------------------------------------------------------------------------
+      // FIFO trigger_o Output
+      //------------------------------------------------------------------------------------------
+      case (reg_read_i.fcr.rx_fifo_tl)
+        2'b00: tl_characters = 4'b0001; // 1 Character
+        2'b01: tl_characters = 4'b0100; // 4 Characters
+        2'b10: tl_characters = 4'b1000; // 8 Characters
+        2'b11: tl_characters = 4'b1110; // 14 Characters
+        default: tl_characters = 4'b0001;
+      endcase
+
+      if (tl_characters <= fifo_usage) begin
+        trigger_o = 1'b1;
+      end
+      //------------------------------------------------------------------------------------------
+      // FIFO Write from RSR
+      //------------------------------------------------------------------------------------------
+      if (write_init) begin
+        if (fifo_full) begin
+          reg_write_o.overrun   = 1'b1;
+          reg_write_o.overrun_valid = 1'b1;
+        end else begin
+          fifo_push       = 1'b1;
+          break_interrupt = & (~{break_q, rsr_q}); // Interrupt if all character bits are 0s
+          fifo_data_i     = {parity_err_q, framing_err_q, break_interrupt, rsr_q}; // 11 Bits
+
+          if (parity_err_q | framing_err_q | break_interrupt) begin
+            fifo_error_index_d         = fifo_usage;
+            reg_write_o.fifo_err       = 1'b1;
+            reg_write_o.fifo_err_valid = 1'b1;
+          end
+        end
+      end
+      //------------------------------------------------------------------------------------------
+      // FIFO timeout
+      //------------------------------------------------------------------------------------------
+      // timeout_level = (character_length * 4) +1
+      character_length = (6'd02 +word_len_bits +reg_read_i.lcr.par_en +reg_read_i.lcr.stop_bits);
+      timeout_level = (character_length << 2) + 6'd01;
+
+      if (reg_read_i.obi_read_rhr | write_init) begin
+        timeout_count_d = '0;
+      end else if (~fifo_empty | rhr_full_q) begin
+        if (baud_rate_edge_i) begin
+          timeout_count_d = timeout_count_q + 1;
+        end
+        if (timeout_count_q == timeout_level) begin
+          timeout_o = 1'b1;
+          timeout_count_d = timeout_count_q;
+        end
+      end
+
+    end // fifo enabled
+
+  end // always_comb
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // FIFO & WRITE RHR Sequential //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  //--FIFO----------------------------------------------------------------------------------------
+  `FF(fifo_error_index_q, fifo_error_index_d, '0, clk_i, rst_ni)
+  `FF(timeout_count_q, timeout_count_d, '0, clk_i, rst_ni)
+
+  //--Write-RHR-----------------------------------------------------------------------------------
+  `FF(rhr_full_q, rhr_full_d, '0, clk_i, rst_ni)
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Statemachine Sequential//
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  //--Statelogic----------------------------------------------------------------------------------
+  `FF(state_q, state_d, RXIDLE, clk_i, rst_ni)
+
+  //--RSR-----------------------------------------------------------------------------------------
+  `FF(rsr_q, rsr_d, '0, clk_i, rst_ni)
+  `FF(bitcount_q, bitcount_d, '0, clk_i, rst_ni)
+
+  //--Parity--------------------------------------------------------------------------------------
+  `FF(parity_err_q, parity_err_d, '0, clk_i, rst_ni)
+
+  //--Stop----------------------------------------------------------------------------------------
+  `FF(framing_err_q, framing_err_d, '0, clk_i, rst_ni)
+
+  //--Break-Interrupt-----------------------------------------------------------------------------
+  `FF(break_q, break_d, '1, clk_i, rst_ni)
+
+endmodule

--- a/hw/obi_uart/obi_uart_tx.sv
+++ b/hw/obi_uart/obi_uart_tx.sv
@@ -1,0 +1,310 @@
+// Copyright 2024 ETH Zurich and University of Bologna.
+// Solderpad Hardware License, Version 0.51, see LICENSE for details.
+// SPDX-License-Identifier: SHL-0.51
+//
+// Authors:
+// - Hannah Pochert  <hpochert@ethz.ch>
+// - Philippe Sauter <phsauter@iis.ee.ethz.ch>
+
+`include "common_cells/registers.svh"
+
+module obi_uart_tx #()
+(
+  input logic  clk_i,
+  input logic  rst_ni,
+
+  input logic  baud_rate_edge_i,
+  input logic  double_rate_edge_i,
+
+  output logic txd_o,
+
+  input obi_uart_pkg::reg_read_t      reg_read_i,
+  output obi_uart_pkg::tx_reg_write_t reg_write_o
+);
+
+  // Import the UART package for definitions and parameters
+  import obi_uart_pkg::*;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Instantiations //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  //--FIFO----------------------------------------------------------------------------------------
+  logic fifo_clear;
+  logic fifo_full;
+  logic fifo_empty;
+  logic [7:0] fifo_data_i;
+  logic [7:0] fifo_data_o;
+  logic fifo_push;
+  logic fifo_pop;
+  logic [3:0] fifo_usage;
+
+  //--THR-Full------------------------------------------------------------------------------------
+  logic thr_full_q, thr_full_d;
+
+  //--Statemachine-Transition-Signals-------------------------------------------------------------
+  state_type_tx_e state_q, state_d;
+
+  logic [2:0] word_len_bits;
+  logic [7:0] word_len_mask;
+
+  //--Statemachine-TSR-Signals--------------------------------------------------------------------
+  logic tsr_empty;
+  logic tsr_finish;
+  logic [7:0] tsr_q, tsr_d;
+  logic [2:0] tsr_count_q, tsr_count_d;
+
+  logic txd_q, txd_d;
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // FIFO Instantiation //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  fifo_v3 # (
+    .FALL_THROUGH(1'b0),
+    .DATA_WIDTH  (8),
+    .DEPTH       (16)
+  ) i_fifo_v3 (
+    .clk_i,
+    .rst_ni,
+    .flush_i   (fifo_clear),  // flush the queue
+    .testmode_i(1'b0      ),
+    // status flags
+    .full_o    (fifo_full),   // queue is full
+    .empty_o   (fifo_empty),  // queue is empty
+    .usage_o   (fifo_usage),  // fill pointer
+    // as long as the queue is not full we can push new data
+    .data_i    (fifo_data_i), // data to push into the queue
+    .push_i    (fifo_push  ), // data is valid and can be pushed to the queue
+    // as long as the queue is not empty we can pop new elements
+    .data_o    (fifo_data_o), // output data
+    .pop_i     (fifo_pop   )  // pop head from queue
+  );
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // General Logic //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  always_comb begin
+    //--------------------------------------------------------------------------------------------
+    // Defaults
+    //--------------------------------------------------------------------------------------------
+    thr_full_d    = thr_full_q;
+    word_len_mask = '0;
+
+    //--FIFO Combinational------------------------------------------------------------------------
+    fifo_clear  = 1'b0;
+    fifo_push   = 1'b0;
+    fifo_data_i = '0;
+
+    //--Register Interface------------------------------------------------------------------------
+    reg_write_o = '0;
+
+    //--Statemachine Combinational----------------------------------------------------------------
+    state_d       = state_q;     // Pass along state
+
+    txd_o         = txd_q & ~reg_read_i.lcr.set_break; // UART Output Assignment
+    txd_d         = txd_q;       // UART Output store for one bit time
+
+    fifo_pop      = 1'b0;        // Read and Remove Byte From FIFO
+
+    tsr_d         = tsr_q;       //TSR
+    tsr_count_d   = tsr_count_q; //TSR
+    tsr_finish    = 1'b0;        //TSR
+    tsr_empty     = 1'b0;        //TSR
+
+    //--------------------------------------------------------------------------------------------
+    // Word Length
+    //--------------------------------------------------------------------------------------------
+    case (reg_read_i.lcr.word_len)
+      2'b00: word_len_bits = 3'b100; // 5 Bits (4th index in tsr)
+      2'b01: word_len_bits = 3'b101; // 6 Bits (5th index in tsr)
+      2'b10: word_len_bits = 3'b110; // 7 Bits (6th index in tsr)
+      2'b11: word_len_bits = 3'b111; // 8 Bits (7th index in tsr)
+      default: word_len_bits = 3'b111;
+    endcase
+
+    for (int i = 0; i <= word_len_bits; i = i + 1) begin
+      word_len_mask[i] = 1'b1;
+    end
+
+    //--------------------------------------------------------------------------------------------
+    // THR Full Flag
+    //--------------------------------------------------------------------------------------------
+    if (reg_read_i.obi_write_thr) begin
+      thr_full_d = 1'b1;
+    end
+
+    //--------------------------------------------------------------------------------------------
+    // Reset LSR
+    //--------------------------------------------------------------------------------------------
+    if (reg_read_i.obi_write_thr) begin
+      reg_write_o.thr_empty   = 1'b0;
+      reg_write_o.tx_empty    = 1'b0;
+      reg_write_o.thr_valid   = 1'b1;
+      reg_write_o.empty_valid = 1'b1;
+    end
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Statemachine Combinational //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    //--------------------------------------------------------------------------------------------
+    // TSR - Transmitter Shift Register (parallel to serial)
+    //--------------------------------------------------------------------------------------------
+    if (state_q == TXDATA & (tsr_count_q <= word_len_bits)) begin
+      txd_d       = tsr_q[tsr_count_q];
+      if (baud_rate_edge_i) begin
+        tsr_count_d = tsr_count_q + 1;
+        tsr_finish  = (tsr_count_q == word_len_bits)? 1'b1 : 1'b0;
+      end
+    end
+
+    //--------------------------------------------------------------------------------------------
+    // State Transition
+    //--------------------------------------------------------------------------------------------
+    case(state_q)
+      TXIDLE: begin
+        txd_d       = 1'b1; // Inactive High
+        tsr_d       = '0;
+        tsr_count_d = 1'b0;
+        tsr_empty   = 1'b1;
+
+        if (reg_read_i.fcr.fifo_en) begin
+          if (~fifo_empty & baud_rate_edge_i) begin // Read FIFO into TSR
+            tsr_d    = fifo_data_o;
+            fifo_pop = 1'b1;
+            state_d  = TXSTART;
+          end
+        end else begin
+          if (thr_full_q & baud_rate_edge_i) begin // Read THR into TSR
+            tsr_d      = reg_read_i.thr.char_tx & word_len_mask;
+            thr_full_d = 1'b0;
+            state_d    = TXSTART;
+          end
+        end
+      end
+
+      TXSTART: begin
+        txd_d   = 1'b0;
+        if (baud_rate_edge_i) begin
+          state_d = TXDATA;
+        end
+      end
+
+      TXDATA: begin
+        if (tsr_finish) begin
+          if (reg_read_i.lcr.par_en) begin
+            state_d = TXPAR;
+          end else begin
+            state_d = TXSTOP1;
+          end
+        end
+      end
+
+      TXPAR: begin
+        case (reg_read_i.lcr[5:4])// Read Parity Configuration
+          2'b00: txd_d = ~(^tsr_q); // Odd Parity
+          2'b01: txd_d = ^tsr_q;    // Even Parity
+          2'b10: txd_d = 1'b1;      // Forced 1
+          2'b11: txd_d = 1'b0;      // Forced 0
+          default: txd_d = 1'b0;
+        endcase
+        if (baud_rate_edge_i) begin
+          state_d = TXSTOP1;
+        end
+      end
+
+      TXSTOP1: begin
+        txd_d = 1'b1;
+        if (reg_read_i.lcr.stop_bits) begin
+          // next transaction starts on next baud_rate_edge_i
+          state_d = TXIDLE;
+        end else if (baud_rate_edge_i) begin
+            state_d = TXSTOP2;
+        end
+      end
+
+      TXSTOP2: begin
+        txd_d = 1'b1;
+        if (word_len_bits == 3'b100) begin
+          // 1.5 stop bits
+          if(double_rate_edge_i) begin
+              state_d = TXIDLE;
+              // TODO: Change active edge to the other double_rate edge to have true 1.5b stop bit
+              // Since RX is a bit flexible this still works but degreades performance minimally
+              // only for a config with 1.5b stop bits.
+          end
+        end else begin
+          state_d = TXIDLE;
+        end
+      end
+
+      default: state_d = TXIDLE;
+    endcase
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // FIFO Combinational //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    if (reg_read_i.fcr.fifo_en) begin
+      //--Reset-FIFO------------------------------------------------------------------------------
+      fifo_clear = 1'b0;
+
+      if (reg_read_i.fcr.tx_fifo_rst) begin
+        fifo_clear = 1'b1;
+        reg_write_o.fifo_rst       = 1'b0;
+        reg_write_o.fifo_rst_valid = 1'b1;
+      end
+
+      //--Set-LSR---------------------------------------------------------------------------------
+      if (fifo_empty) begin
+        reg_write_o.thr_empty = 1'b1;
+        reg_write_o.thr_valid = 1'b1;
+        if (tsr_empty) begin
+          reg_write_o.tx_empty    = 1'b1;
+          reg_write_o.empty_valid = 1'b1;
+        end
+      end
+
+      //--Write-FIFO-from-THR---------------------------------------------------------------------
+      if (thr_full_q & (~fifo_full)) begin
+        fifo_push   = 1'b1;
+        fifo_data_i = reg_read_i.thr.char_tx & word_len_mask;
+        thr_full_d  = 1'b0;
+      end
+    end
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // THR Combinational //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+    if (~reg_read_i.fcr.fifo_en) begin
+      //--Keep-FIFO-cleared-----------------------------------------------------------------------
+      fifo_clear = 1'b1;
+      //--Set-LSR---------------------------------------------------------------------------------
+      if (~thr_full_q) begin
+        reg_write_o.thr_empty = 1'b1;
+        reg_write_o.thr_valid = 1'b1;
+        if (tsr_empty) begin
+          reg_write_o.tx_empty    = 1'b1;
+          reg_write_o.empty_valid = 1'b1;
+        end
+      end
+    end
+
+  end
+
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+  // Sequential //
+  ////////////////////////////////////////////////////////////////////////////////////////////////
+
+  `FF(thr_full_q, thr_full_d, '0, clk_i, rst_ni)
+
+  `FF(tsr_q, tsr_d, '0, clk_i, rst_ni)
+  `FF(tsr_count_q, tsr_count_d, '0, clk_i, rst_ni)
+
+  `FF(txd_q, txd_d, '1, clk_i, rst_ni)
+
+  `FF(state_q, state_d, TXIDLE, clk_i, rst_ni)
+
+endmodule


### PR DESCRIPTION
This is the OBI-based UART 16550 peripheral developed originally for [Croc](https://github.com/pulp-platform/croc) by a student (Hannah Pochert).