### PR TITLE
obi_uart: Fix register write assignments

### DIFF
--- a/hw/obi_uart/obi_uart_register.sv
+++ b/hw/obi_uart/obi_uart_register.sv
@@ -82,7 +82,7 @@ module obi_uart_register import obi_uart_pkg::*; #(
   tx_reg_write_t write_tx;
 
   assign write_tx = reg_write_i.tx;
-  assign write_rx = reg_write_i.tx;
+  assign write_rx = reg_write_i.rx;
 
   // output current register values
   assign reg_read_o.thr = reg_q.THR;
@@ -96,10 +96,6 @@ module obi_uart_register import obi_uart_pkg::*; #(
 
   //-- Internal updates to registers -------------------------------------------------------------
   always_comb begin : hw_update
-    // shorthand signal names
-    rx_reg_write_t write_rx = reg_write_i.rx;
-    tx_reg_write_t write_tx = reg_write_i.tx;
-
     // default
     new_reg = reg_q;
 


### PR DESCRIPTION
* `write_rx` and `write_tx` are already declared and assigned outside the `always_comb` block. This causes errors when elaborating the design.
* `write_tx` was assigned incorrectly to the same signal as `write_rx`.