### PR TITLE
obi_uart: Fix break interrupt behavior

### DIFF
--- a/hw/obi_uart/obi_uart_interrupts.sv
+++ b/hw/obi_uart/obi_uart_interrupts.sv
@@ -47,7 +47,7 @@ module obi_uart_interrupts import obi_uart_pkg::*; #()
   always_comb begin
     //--Receive-Line-Status-Interrupt-------------------------------------------------------------
     intrpt_reg_d.rls = reg_read_i.ier.rlstat & (reg_write_i.rx.overrun | reg_write_i.rx.par_err |
-                        reg_write_i.rx.frame_err | reg_write_i.rx.break_irq);
+                        reg_write_i.rx.frame_err | reg_write_i.rx.break_ind);
 
     //--Receive-Data-Ready-Interrupt--------------------------------------------------------------
     if (reg_read_i.fcr.fifo_en) begin

--- a/hw/obi_uart/obi_uart_pkg.sv
+++ b/hw/obi_uart/obi_uart_pkg.sv
@@ -133,10 +133,10 @@ package obi_uart_pkg;
     logic fifo_err;          // FIFO Data Error
     logic tx_empty;          // Transmitter Empty (no bits to send)
     logic thr_empty;         // THR (and FIFO) Empty
-    logic break_irq;      // Break Interrupt
+    logic break_ind;         // Break Indicator
     logic frame_err;         // Framing Error
     logic par_err;           // Parity Error
-    logic overrun;       // Overrun Error
+    logic overrun;           // Overrun Error
     logic data_ready;        // Data Ready
   } lsr_bits_t;
 
@@ -235,7 +235,7 @@ package obi_uart_pkg;
     logic       overrun;
     logic       par_err;
     logic       frame_err;
-    logic       break_irq;
+    logic       break_ind;
 
     logic       rhr_valid;
     logic       fifo_rst_valid;

--- a/hw/obi_uart/obi_uart_register.sv
+++ b/hw/obi_uart/obi_uart_register.sv
@@ -109,7 +109,7 @@ module obi_uart_register import obi_uart_pkg::*; #(
     new_reg.LSR.fifo_err   = write_rx.fifo_err_valid ? write_rx.fifo_err   : reg_q.LSR.fifo_err;
     new_reg.LSR.tx_empty   = write_tx.empty_valid    ? write_tx.tx_empty   : reg_q.LSR.tx_empty;
     new_reg.LSR.thr_empty  = write_tx.thr_valid      ? write_tx.thr_empty  : reg_q.LSR.thr_empty;
-    new_reg.LSR.break_irq  = write_rx.break_valid    ? write_rx.break_irq  : reg_q.LSR.break_irq;
+    new_reg.LSR.break_ind  = write_rx.break_valid    ? write_rx.break_ind  : reg_q.LSR.break_ind;
     new_reg.LSR.frame_err  = write_rx.frame_valid    ? write_rx.frame_err  : reg_q.LSR.frame_err;
     new_reg.LSR.par_err    = write_rx.par_valid      ? write_rx.par_err    : reg_q.LSR.par_err;
     new_reg.LSR.data_ready = write_rx.dr_valid       ? write_rx.data_ready : reg_q.LSR.data_ready;


### PR DESCRIPTION
- better distinguish between interrupt and indicator
- it must only be sampled once if line does not return to idle
- indicator is shown even if interrupt disabled
- interrupt must appear after the correct length of logic-low